### PR TITLE
Corrects some company names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We didn't get to add every webhook we wanted! Here are some we'd love to include
 
 1. 8x8 - https://developer.8x8.com/contactcenter/docs/verify-webhook-callbacks
 1. Active Campaign - https://www.activecampaign.com/blog/working-with-webhook-data
-1. Adobe Acrobat Sign (both approaches) - https://helpx.adobe.com/sign/using/adobe-sign-webhooks-api.html & 
+1. Adobe Acrobat Sign (both approaches) - https://helpx.adobe.com/sign/using/adobe-sign-webhooks-api.html &
 1. Aftership - https://developers.aftership.com/reference/check-signatures
 1. Akamai Identity Cloud - https://janrain-education-center.knowledgeowl.com/home/json-web-keys
 1. Asana - https://developers.asana.com/docs/webhook-security
@@ -43,7 +43,7 @@ We didn't get to add every webhook we wanted! Here are some we'd love to include
 1. Docusign - https://developers.docusign.com/platform/webhooks/connect/hmac/
 1. Fivetran - https://fivetran.com/docs/rest-api/webhooks#signing
 1. Front - https://dev.frontapp.com/docs/webhooks-1
-1. Gitlab - https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#validate-payloads-by-using-a-secret-token
+1. GitLab - https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#validate-payloads-by-using-a-secret-token
 1. Goldman Sachs Dev - https://developer.gs.com/docs/services/transaction-banking/webhooks-auth/
 1. Greenhouse - https://developers.greenhouse.io/webhooks.html#creating-a-web-hook
 1. Mandrill/Mailchimp - https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
@@ -52,7 +52,7 @@ We didn't get to add every webhook we wanted! Here are some we'd love to include
 1. Okta	- Event Hooks - https://developer.okta.com/docs/concepts/event-hooks/#one-time-verification-request
 1. Olark - https://www.olark.com/help/webhooks
 1. One Drive - https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/webhook-receiver-validation-request?view=odsp-graph-online
-1. Paypal - https://developer.paypal.com/docs/api-basics/notifications/webhooks/notification-messages/#event-headers
+1. PayPal - https://developer.paypal.com/docs/api-basics/notifications/webhooks/notification-messages/#event-headers
 1. Plaid - https://plaid.com/docs/api/webhooks/webhook-verification/
 1. Segment - https://segment.com/docs/connections/destinations/catalog/webhooks/#appendices
 1. SendGrid - https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook-security-features

--- a/src/pages/best-practices/webhook-consumers.md
+++ b/src/pages/best-practices/webhook-consumers.md
@@ -1,7 +1,7 @@
 ---
 title: Best Practices for Webhook Consumers
 description: Security Best Practices for Webhook Consumers
---- 
+---
 
 In addition to using a good webhook provider and implementation, you can take the following steps to improve your webhook security:
 
@@ -9,7 +9,7 @@ In addition to using a good webhook provider and implementation, you can take th
 
 * **Review the webhook documentation and ensure you're implementing all the security features offered:** in webhook communications, the authentication, message integrity validation, and replay prevention validation, and enforcement happen on the webhook listener. Therefore, you should read, understand, and implement the security controls made available by your provider.
 
-* **Restrict who can send you webhook requests based on the IP**: Some services — i.e. [Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses) and [Zoom](https://marketplace.zoom.us/docs/api-reference/webhook-reference/#ip-addresses) — provide a public list of IPs used in their service to send you webhook notifications. You can use this list to implement network restrictions and ensure only the webhook service is sending notifications. Note that this may not be possible if the webhook service does not provide a list of their origin IPs.
+* **Restrict who can send you webhook requests based on the IP**: Some services — i.e. [GitHub](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-githubs-ip-addresses) and [Zoom](https://marketplace.zoom.us/docs/api-reference/webhook-reference/#ip-addresses) — provide a public list of IPs used in their service to send you webhook notifications. You can use this list to implement network restrictions and ensure only the webhook service is sending notifications. Note that this may not be possible if the webhook service does not provide a list of their origin IPs.
 
 * **Storing secrets**: Credentials and shared secrets should be treated as confidential information and handled like private keys (stored appropriately both by the webhook service and listener in production usage).
 
@@ -21,6 +21,6 @@ In addition to using a good webhook provider and implementation, you can take th
 
 * **Call back the service:** An interesting method to validate if a webhook request is legitimate is to call the service that sent the webhook from a different channel, such as their REST API, to confirm said event happened. Some services — i.e., Atlassian Jira — will include an API endpoint in the webhook body to facilitate the validation. However, this approach impacts performance and time to value.
 
-{% diagram-callback / %} 
+{% diagram-callback / %}
 
 _Webhook notification with API callback_

--- a/src/pages/security/jwt-jwk-oauth2.md
+++ b/src/pages/security/jwt-jwk-oauth2.md
@@ -1,7 +1,7 @@
 ---
 title: OAuth2, JWTs, and JWKs
 description: Learn how webhook providers use OAuth, JSON Web Tokens (JWTs), and JSON Web Keys (JWKs) in creative ways to protect their webhooks
---- 
+---
 
 {% table %}
 ---
@@ -22,15 +22,15 @@ description: Learn how webhook providers use OAuth, JSON Web Tokens (JWTs), and 
 * - [Akamai/Janrain](https://janrain-education-center.knowledgeowl.com/home/json-web-keys)
   - [Brex](https://developer.brex.com/openapi/webhooks_api/#operation/listSecrets)
   - [Plaid](https://plaid.com/docs/api/webhooks/webhook-verification/)
-  - [Sendgrid](https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook-security-features#oauth-20)
+  - [SendGrid](https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook-security-features#oauth-20)
   - [Wix](https://devforum.wix.com/kb/en/article/about-webhooks)
-  
+
 {% /table %}
 ---
 
-Webhook providers such as Sendgrid, Wix, and Brex use security methods and protocols typically found in REST APIs — such as OAuth, JSON Web Tokens (JWTs), and JSON Web Keys (JWKs) — in creative ways to protect their webhooks:
+Webhook providers such as SendGrid, Wix, and Brex use security methods and protocols typically found in REST APIs — such as OAuth, JSON Web Tokens (JWTs), and JSON Web Keys (JWKs) — in creative ways to protect their webhooks:
 
-* **Sendgrid uses OAuth as a client.** Before sending a webhook message, Sendgrid authorizes itself against third-party OAuth Authorization Servers to issue access tokens. Webhook listeners must validate the OAuth token to ensure the request is trusted and authorized using the validation method defined by the OAuth Authorization Server.
+* **SendGrid uses OAuth as a client.** Before sending a webhook message, SendGrid authorizes itself against third-party OAuth Authorization Servers to issue access tokens. Webhook listeners must validate the OAuth token to ensure the request is trusted and authorized using the validation method defined by the OAuth Authorization Server.
 * **Brex uses OAuth to release webhook keys.** Brex uses HMAC with symmetric SHA256 keys for webhook validation. However, webhook listeners must request a REST API (GET /v1/webhooks/secrets) protected with OAuth to obtain the shared key. The call should happen regularly to prevent downtime after a key rotation.
 * **Wix uses JWT in the webhook payload.** Wix implements JWT in the webhook payload. Webhook listeners validate the webhook signature following the JWT standard, using a public certificate provided by Wix in the webhook registration.
 * **Janrain (an Akamai product) uses JWKs and JWTs in webhook notifications.** Janrain takes a similar approach to Wix and sends a JWT in the webhook payload for validation. However, instead of shipping public certificates in the webhook registration, they implement the JSON Web Key (JWK) standard and endpoint to obtain the public keys for webhook validation.


### PR DESCRIPTION
Noticed that GitHub was misspelled in one place, then spotted a few other names. Added the correct camel casing for GitHub, GitLab, SendGrid and PayPal.