### PR TITLE
Webhook Provider update for Maxio Chargify

### DIFF
--- a/src/pages/docs/webhook-directory.md
+++ b/src/pages/docs/webhook-directory.md
@@ -17,7 +17,7 @@ New webhooks are created and improved every day. Please [contribute](/docs/how-t
   {% webhook-entry provider="Buildkite" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="✅" link="https://buildkite.com/docs/apis/webhooks" /%}
   {% webhook-entry provider="Calendly" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="✅" link="https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-webhook-signatures" /%}
   {% webhook-entry provider="Castle" hash="sha256" encode="base64" rotation="❌" versioning="❌" timestamp="❌" link="https://docs.castle.io/docs/subscribe-to-webhooks" /%}
-  {% webhook-entry provider="Chargify" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://chargify.zendesk.com/hc/en-us/articles/4407905415963-Webhooks-Reference#webhook-signature" /%}
+  {% webhook-entry provider="Maxio Chargify" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://maxio-chargify.zendesk.com/hc/en-us/articles/5405357509645-Webhooks-Reference#webhook-signature" /%}  
   {% webhook-entry provider="CircleCI" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="❌" link="https://circleci.com/docs/2.0/webhooks/" /%}
   {% webhook-entry provider="Coinbase" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://docs.cloud.coinbase.com/commerce/docs/webhooks-fields-and-security" /%}
   {% webhook-entry provider="Contentful" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="✅" link="https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/" /%}

--- a/src/pages/docs/webhook-directory.md
+++ b/src/pages/docs/webhook-directory.md
@@ -17,7 +17,7 @@ New webhooks are created and improved every day. Please [contribute](/docs/how-t
   {% webhook-entry provider="Buildkite" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="✅" link="https://buildkite.com/docs/apis/webhooks" /%}
   {% webhook-entry provider="Calendly" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="✅" link="https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-webhook-signatures" /%}
   {% webhook-entry provider="Castle" hash="sha256" encode="base64" rotation="❌" versioning="❌" timestamp="❌" link="https://docs.castle.io/docs/subscribe-to-webhooks" /%}
-  {% webhook-entry provider="Maxio Chargify" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://maxio-chargify.zendesk.com/hc/en-us/articles/5405357509645-Webhooks-Reference#webhook-signature" /%}  
+  {% webhook-entry provider="Maxio Chargify" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://maxio-chargify.zendesk.com/hc/en-us/articles/5405357509645-Webhooks-Reference#webhook-signature" /%}
   {% webhook-entry provider="CircleCI" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="❌" link="https://circleci.com/docs/2.0/webhooks/" /%}
   {% webhook-entry provider="Coinbase" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://docs.cloud.coinbase.com/commerce/docs/webhooks-fields-and-security" /%}
   {% webhook-entry provider="Contentful" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="✅" link="https://www.contentful.com/developers/docs/extensibility/app-framework/request-verification/" /%}


### PR DESCRIPTION
### Changelog

1. Updated chargify webhook reference link
2. Updated name to `Maxio Chargify` as per the [rebranding](https://www.businesswire.com/news/home/20220413005024/en/SaaSOptics-and-Chargify-Announce-Merger-Rebrand-to-Maxio) and docs