### PR TITLE
Add Keygen

### DIFF
--- a/src/pages/docs/webhook-directory.md
+++ b/src/pages/docs/webhook-directory.md
@@ -35,6 +35,7 @@ New webhooks are created and improved every day. Please [contribute](/docs/how-t
   {% webhook-entry provider="HubSpot V2" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="❌" link="https://developers.hubspot.com/docs/api/webhooks/validating-requests" /%}
   {% webhook-entry provider="HubSpot V3" hash="sha256" encode="base64" rotation="❌" versioning="✅" timestamp="✅" link="https://developers.hubspot.com/docs/api/webhooks/validating-requests" /%}
   {% webhook-entry provider="Intercom" hash="sha1" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://developers.intercom.com/intercom-api-reference/v1.0/reference/signed-notifications" /%}
+  {% webhook-entry provider="Keygen" hash="sha256" encode="base64" rotation="❌" versioning="✅" timestamp="✅" link="https://keygen.sh/docs/api/webhooks/" /%}
   {% webhook-entry provider="LaunchDarkly" hash="sha256" encode="hex" rotation="❌" versioning="❌" timestamp="❌" link="https://docs.launchdarkly.com/home/connecting/webhooks" /%}
   {% webhook-entry provider="Lob" hash="sha256" encode="hex" rotation="❌" versioning="✅" timestamp="✅" link="https://help.lob.com/print_mail/webhooks-for-tracking-events" /%}
   {% webhook-entry provider="Mailchimp" hash="sha1" encode="base64" rotation="❌" versioning="❌" timestamp="❌" link="https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests" /%}

--- a/src/pages/security/asymmetric-key-signatures.md
+++ b/src/pages/security/asymmetric-key-signatures.md
@@ -1,5 +1,5 @@
 ---
-title: Asymmetric Key Signature (ECDSA and RSA) 
+title: Asymmetric Key Signature (EdDSA, ECDSA and RSA)
 description: With Asymmetric Key Signatures, webhook providers use a private key to sign requests and listeners use a public key to validate webhook calls
 --- 
 
@@ -19,19 +19,20 @@ description: With Asymmetric Key Signatures, webhook providers use a private key
 * **Examples**
 * - [Sendgrid](https://docs.sendgrid.com/for-developers/tracking-events/getting-started-event-webhook-security-features)
   - [PayPal](https://developer.paypal.com/docs/api-basics/notifications/webhooks/notification-messages/#event-headers)
+  - [Keygen](https://keygen.sh/docs/api/signatures/#webhook-signatures)
 {% /table %}
 ---
 
-In our research, we found a couple of providers — PayPal and SendGrid — using asymmetric keys for signing for webhook messages. In this method, the webhook provider uses a private key to sign requests while the listener uses a public key to validate webhook calls. At a conceptual level, the process works as follows:
+In our research, we found a few providers — such as PayPal and SendGrid — using asymmetric keys for signing for webhook messages. In this method, the webhook provider uses a private key to sign requests while the listener uses a public key to validate webhook calls. At a conceptual level, the process works as follows:
 
 1. On webhook requests, the provider signs the webhook message using its private key and adds the signature to the webhook request as a header.
-2. The webhook listener receives the request and runs an ECDSA or RSA verifier with the public key, the request body, and the signed value from the provider. If the verifier returns positive, it means that the private key could only create the signature, and the request is considered legit.
+2. The webhook listener receives the request and runs an EdDSA, ECDSA or RSA verifier with the public key, the request body, and the signed value from the provider. If the verifier returns positive, it means that the private key could only create the signature, and the request is considered legit.
 
 ## Asymmetric key signatures vs HMAC
 
 The major difference between HMAC and asymmetric key signatures is in the verification process. In HMAC, webhook listeners generate the same signature from the provider using the same key to validate the request. With asymmetric signatures, listeners cannot generate the same signature. Instead, they use a verifier with the public key to confirm if the request is legit.
 
-This difference in verification logic delivers non-repudiation. In HMAC, anyone with access to the private key can generate a webhook request. However, with asymmetric keys, only the webhook provider — in possession of the private key — can sign webhook messages. 
+This difference in verification logic delivers non-repudiation. In HMAC, anyone with access to the private key can generate a webhook request. However, with asymmetric keys, only the webhook provider — in possession of the private key — can sign webhook messages.
 
 Webhook implementations with asymmetric keys can also use the same techniques as HMAC providers to add [replay prevention](/security/replay-prevention), [versioning](/ops-experience/versioning), and [key rotation](/ops-experience/key-rotation). SendGrid, for example, implements a timestamp header ( `X-Twilio-Email-Event-Webhook-Timestamp` ) within the payload to mitigate replay attacks.
 

--- a/src/pages/security/replay-prevention.md
+++ b/src/pages/security/replay-prevention.md
@@ -22,6 +22,7 @@ description: Learn how webhook providers leverage signed timestamps to mitigate 
   - [Slack](https://api.slack.com/authentication/verifying-requests-from-slack)
   - [PayPal](https://developer.paypal.com/api/rest/webhooks/#link-eventheadervalidation)
   - [Zendesk](https://developer.zendesk.com/documentation/event-connectors/webhooks/verifying/)
+  - [Keygen](https://keygen.sh/docs/api/signatures/#webhook-signatures)
 {% /table %}
 ---
 


### PR DESCRIPTION
Let me know if anything needs to be changed. [Keygen](https://keygen.sh) uses Ed25519 for webhook signatures. We implemented the [Cavage spec](https://datatracker.ietf.org/doc/html/draft-cavage-http-signatures-12) for HTTP signatures, which has replay prevention by including the `Date` header in the signing data.

p.s. I had to manually run `yarn add @markdoc/markdoc` to get things to compile locally.