### PR TITLE
Add webhooks on AWS blog post

### DIFF
--- a/src/pages/learn-more/resources.md
+++ b/src/pages/learn-more/resources.md
@@ -11,4 +11,8 @@ Awesome Webhooks provides a curated list of tutorials, guides, and articles abou
 
 Huge shout out to [@_adeel](https://twitter.com/_adeel) for building and curating this list.
 
-[Visit Awesome Webhooks >>](https://github.com/realadeel/awesome-webhooks)
+## [Webhooks on AWS: Innovate with event notifications](https://aws.amazon.com/blogs/compute/sending-and-receiving-webhooks-on-aws-innovate-with-event-notifications/)
+
+Are you building webhooks on AWS? See blog post for high-level reference architectures with considerations, best practices and code sample to guide your implementation.
+
+[Visit AWS Blog >>](https://aws.amazon.com/blogs/compute/sending-and-receiving-webhooks-on-aws-innovate-with-event-notifications/)


### PR DESCRIPTION
Created AWS blog post to link to webhooks.fyi to help builders adopt best-practices when building with webhooks